### PR TITLE
Remove openvswitch-datapath-dkms from a comment

### DIFF
--- a/ubuntu14.04/hagistack_controller_single-nic.sh
+++ b/ubuntu14.04/hagistack_controller_single-nic.sh
@@ -7,7 +7,7 @@
 #prerequisite make lvm cinder-volumes and setting hosts and Openvswitch Install and NIC Setting
 #Number of necessary NIC 1
 ###networking settings
-sudo apt-get install openvswitch-switch openvswitch-datapath-dkms -y
+sudo apt-get install openvswitch-switch -y
 # change interface settings
 ### Before Change Bridge Interface ###
 auto eth0


### PR DESCRIPTION
「mada totyuu」とのことなので動かないのは認識していますが、hagistackをUbuntu 14.04で試させていただいています。

スクリプトを読むと、Open vSwitchを先に構成する必要がありそうでしたので、コメント通り試してみたところ、
openvswitch-datapath-dkmsのインストールでエラー(後述)になってしまいました。

リリースノートを見ると、カーネルに同等の機能が含まれているようでした。インストールしなくても疎通はできるようでしたので、報告の意味でPull Requestします(とくに不要でしたら単に破棄してください)
https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes/Ja

> 注意: openvswitch-datapath-dkmsパッケージは、14.04 LTSでデフォルトで利用されるLinux 3.13カーネルと互換性がありません。3.13カーネルに含まれる非DKMSモジュールは、基本的にopenvswitch-datapath-dkmsと同等の機能を持っているため、これを代わりに利用することになるでしょう（ただし、実験的機能であるLISPトンネリングは含まれません）。 
# エラー

```
./configure --with-linux='/lib/modules/3.13.0-24-generic/build' && make -C datapath/linux....(bad exit status: 1)
Error! Bad return status for module build on kernel: 3.13.0-24-generic (x86_64)
Consult /var/lib/dkms/openvswitch/2.0.1+git20140120/build/make.log for more information.
```
# make.log

```
checking for kernel version... 3.13.9
configure: error: Linux kernel in /lib/modules/3.13.0-24-generic/build is version 3.13.9, but version newer than 3.12.x is not supported
```
